### PR TITLE
build: Update Github Actions to use Java 20 and JavaFX 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: oracle-actions/setup-java@v1
         with:
           website: jdk.java.net
-          release: 19
+          release: 20
 
       - name: Run Tests (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/bundles-kit.yml
+++ b/.github/workflows/bundles-kit.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       java-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
 

--- a/.github/workflows/bundles-linux.yml
+++ b/.github/workflows/bundles-linux.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       javafx-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-mac.yml
+++ b/.github/workflows/bundles-mac.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       javafx-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-mac_aarch64.yml
+++ b/.github/workflows/bundles-mac_aarch64.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       javafx-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       test:

--- a/.github/workflows/bundles-windows.yml
+++ b/.github/workflows/bundles-windows.yml
@@ -10,11 +10,11 @@ on:
         required: true
         type: string
       java-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       javafx-version:
-        default: '19'
+        default: '20'
         required: false
         type: string
       test:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -5,8 +5,8 @@ on:
     branches: [ master ]
 
 env:
-  JAVAFX_VERSION: '19'
-  JAVA_VERSION: '19'
+  JAVAFX_VERSION: '20'
+  JAVA_VERSION: '20'
 
 jobs:
   precheck:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
 
 env:
-  JAVAFX_VERSION: '19'
-  JAVA_VERSION: '19'
+  JAVAFX_VERSION: '20'
+  JAVA_VERSION: '20'
 
 jobs:
   precheck:


### PR DESCRIPTION
### Issue

Fixes #617

Upgrades Github Actions to use the new JavaFX 20 and new Java 20.

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)