### PR TITLE
Issue 811

### DIFF
--- a/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContext.java
+++ b/kit/src/main/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2025, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,6 +31,7 @@
  */
 package com.oracle.javafx.scenebuilder.kit.skeleton;
 
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMIntrinsic;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
 import com.oracle.javafx.scenebuilder.kit.fxom.FXOMPropertyT;
 import com.oracle.javafx.scenebuilder.kit.util.eventnames.EventNames;
@@ -41,11 +42,14 @@ import javafx.fxml.FXML;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class SkeletonContext {
 
@@ -135,12 +139,40 @@ public class SkeletonContext {
 
         public void addFxId(FXOMObject value) {
             String fxId = value.getFxId();
-            Class<?> type = value.getSceneGraphObject().getClass();
-
+            getSceneGraphType(value).ifPresent(type -> addToSkeleton(type, fxId));           
+        }
+        
+        private void addToSkeleton(Class<?> type, String fxId) {
             addImportsFor(FXML.class, type);
-
             variables.put(fxId, type);
             assertions.add(fxId);
+        }
+
+        private Optional<Class<?>> getSceneGraphType(FXOMObject value) {
+            /*
+             * For fx:include elements, the FXOMIntrinsic objects deliver null values 
+             * when the method getSceneGraphObject() is called, which is inherited 
+             * from FXOMObject. But when calling getSourceSceneGraphObject()
+             * the root node of the included FXML is exposed and one can
+             * obtain its type.
+             * 
+             */
+            Object node = null;
+            if (value instanceof FXOMIntrinsic intrinsic
+                    && FXOMIntrinsic.Type.FX_INCLUDE.equals(intrinsic.getType())) {
+                node = intrinsic.getSourceSceneGraphObject();
+            } else {
+                node = value.getSceneGraphObject();
+            }
+            
+            if (null == node) {
+                String message = "Failed to obtain type for: <%s fx:id=\"%s\" />";
+                Logger.getLogger(getClass().getName())
+                      .log(Level.WARNING, message.formatted(value.getGlueElement().getTagName(), value.getFxId()));
+                return Optional.empty();
+            }
+
+            return Optional.of(node.getClass());
         }
 
         public void addEventHandler(FXOMPropertyT eventHandler) {

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonBufferJavaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2025, Gluon and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -45,6 +45,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.List;
 
 public class SkeletonBufferJavaTest {
 
@@ -103,6 +104,19 @@ public class SkeletonBufferJavaTest {
 
         // then
         assertEqualsFileContent("skeleton_java_full.txt", skeleton);
+    }
+    
+    @Test
+    public void that_fxinclude_elements_with_fxid_are_properly_referenced() throws IOException {
+        // given
+        SkeletonBuffer skeletonBuffer = load("fxinclude_with_fxid_outer.fxml");
+        skeletonBuffer.setFormat(SkeletonSettings.FORMAT_TYPE.FULL);
+        
+        // when
+        List<String> skeleton = skeletonBuffer.toString().lines().toList();
+                
+        assertEquals("@FXML", skeleton.get(19).trim());
+        assertEquals("private Pane includedPane;", skeleton.get(20).trim());
     }
 
     private void assertEqualsFileContent(String fileName, String actual) {

--- a/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContextTest.java
+++ b/kit/src/test/java/com/oracle/javafx/scenebuilder/kit/skeleton/SkeletonContextTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025, Gluon and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
+ *
+ * This file is available and licensed under the following license:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.javafx.scenebuilder.kit.skeleton;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ResourceBundle;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.oracle.javafx.scenebuilder.kit.JfxInitializer;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMDocument;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMIntrinsic;
+import com.oracle.javafx.scenebuilder.kit.fxom.FXOMObject;
+import com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonContext.Builder;
+import com.oracle.javafx.scenebuilder.kit.skeleton.SkeletonSettings.FORMAT_TYPE;
+
+class SkeletonContextTest {
+    
+    @BeforeAll
+    public static void init() {
+        JfxInitializer.initialize();
+    }
+
+    @Test
+    void that_fxinclude_with_fxid_is_added_to_skeleton_context_without_error() throws IOException {
+        // SETUP
+        String documentName = "fxinclude_with_fxid_outer.fxml";       
+        FXOMDocument doc = createDocument(documentName);
+        Builder builder = SkeletonContext.builder()
+                                         .withDocumentName(documentName)
+                                         .withSettings(new SkeletonSettings());
+                
+        /* Obtain the SceneGraph object reference and add it to the context */
+        FXOMObject object = doc.searchWithFxId("includedPane");
+        
+        // TEST
+        assertDoesNotThrow(() -> builder.addFxId(object));
+
+        SkeletonContext classUnderTest = builder.build();       
+        assertAll(
+            () -> assertTrue(object instanceof FXOMIntrinsic),
+            () -> assertTrue(classUnderTest.getImports().contains("import javafx.scene.layout.Pane")),
+            () -> assertTrue(classUnderTest.getVariables().get("includedPane").equals(javafx.scene.layout.Pane.class)),
+            () -> assertTrue(classUnderTest.getAssertions().contains("includedPane"))
+        );
+    }
+    
+    @Test
+    void that_label_with_fxid_is_only_added_once() throws IOException {
+        // SETUP
+        String documentName = "fxinclude_with_fxid_outer.fxml";
+        FXOMDocument doc = createDocument(documentName);
+        Builder builder = SkeletonContext.builder()
+                                         .withDocumentName(documentName)
+                                         .withSettings(new SkeletonSettings().withFormat(FORMAT_TYPE.FULL));
+        
+        /* Obtain the SceneGraph object reference and add it to the context */
+        FXOMObject object = doc.searchWithFxId("myLabel");
+        
+        // TEST
+        assertDoesNotThrow(() -> builder.addFxId(object));
+                
+        SkeletonContext classUnderTest = builder.build();       
+        assertAll(
+            () -> assertFalse(object instanceof FXOMIntrinsic),
+            () -> assertTrue(classUnderTest.getImports().contains("import javafx.scene.control.Label")),
+            () -> assertTrue(classUnderTest.getVariables().get("myLabel").equals(javafx.scene.control.Label.class)),
+            () -> assertTrue(classUnderTest.getAssertions().contains("myLabel"))
+        );
+    }
+
+    private FXOMDocument createDocument(String documentName) throws IOException {
+        final URL fxmlURL = SkeletonBufferJavaTest.class.getResource(documentName);
+        String document = FXOMDocument.readContentFromURL(fxmlURL);
+        ClassLoader classLoader = null;
+        ResourceBundle resourceBundle = null;
+        FXOMDocument doc = new FXOMDocument(document, fxmlURL, classLoader, resourceBundle);
+        return doc;
+    }
+    
+
+}

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/fxinclude_with_fxid_inner.fxml
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/fxinclude_with_fxid_inner.fxml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.Pane?>
+
+
+<Pane fx:id="embeddedPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/21.0.3-internal" xmlns:fx="http://javafx.com/fxml/1" />

--- a/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/fxinclude_with_fxid_outer.fxml
+++ b/kit/src/test/resources/com/oracle/javafx/scenebuilder/kit/skeleton/fxinclude_with_fxid_outer.fxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.collections.FXCollections ?>
+<?import java.lang.String ?>
+
+<Pane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/23" xmlns:fx="http://javafx.com/fxml/1">
+   <children>
+      <HBox prefHeight="100.0" prefWidth="200.0">
+         <children>
+            <fx:include fx:id="includedPane" source="fxinclude_with_fxid_inner.fxml" />
+            <Label fx:id="myLabel" text="Label" />
+            <Label fx:id="myLabel" text="Label" />
+			<ComboBox fx:id="descriptionFilter" editable="true" layoutX="226.0" layoutY="55.0" prefHeight="25.0" prefWidth="204.0" promptText="Series Description">
+				<items>
+					<FXCollections fx:id="myItems" fx:factory="observableArrayList">
+						<String fx:value="1" />
+						<String fx:value="20" />
+						<String fx:value="300" />
+					</FXCollections>
+				</items>
+			</ComboBox>
+         </children>
+      </HBox>
+
+   </children>
+</Pane>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
                         <argLine>
                             --add-opens=javafx.fxml/javafx.fxml=com.gluonhq.scenebuilder.kit -Djavafx.allowjs=true --enable-native-access=javafx.graphics
                             --add-opens com.gluonhq.scenebuilder.kit/com.oracle.javafx.scenebuilder.kit.metadata.util=ALL-UNNAMED
+                            --add-opens com.gluonhq.scenebuilder.kit/com.oracle.javafx.scenebuilder.kit.skeleton=ALL-UNNAMED
                         </argLine>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
This PR introduces code which enables Scene Builder to declare references to `<fx:include>` elements which have a `fx:id` assigned in the controller skeleton. It uses the `fx:id` defined in the outer FXML file but the type of the node declared as root in the inner FXML file.

### Issue

Fixes #811 

### Progress

- [x] Change must not contain extraneous whitespace
- [x] License header year is updated, if required
- [x] The PR name must follow the [pre-defined format](https://github.com/gluonhq/scenebuilder/blob/master/CONTRIBUTING.md)
- [x] Verify the contributor has signed [Gluon Individual Contributor License Agreement (CLA)](https://docs.google.com/forms/d/16aoFTmzs8lZTfiyrEm8YgMqMYaGQl0J8wA0VJE2LCCY)